### PR TITLE
Fix for FreeBSD

### DIFF
--- a/src/mediascan.c
+++ b/src/mediascan.c
@@ -1198,6 +1198,8 @@ void ms_scan_file(MediaScan *s, const char *full_path, enum media_type type) {
   else {
     strcpy(tmp_full_path, full_path);
   }
+#else
+  strcpy(tmp_full_path, full_path); //Some reasonable default for other OS (e.g. FreeBSD)
 #endif
 
   // Check if the file has been recently scanned


### PR DESCRIPTION
There is a place in the code, which has a logic if darwin ... else if linux ... else if win. For FreeBSD it ends up with non initialized variable and does not work. This is a simple fix for that. Better fix would check for links, but at least it works now.
